### PR TITLE
Slide page is now sometimes modulation page

### DIFF
--- a/k2z.lua
+++ b/k2z.lua
@@ -268,7 +268,7 @@ function make_scale()
 	return new_scale
 end
 
-function note_clock(track,note,duration,slide_amt)
+function note_clock(track,note,duration,slide_or_modulate)
 	local player = params:lookup_param("voice_t"..track):get_player()
 	local velocity = 1.0
 	local divider = data:get_page_val(track,'trig','divisor')
@@ -279,11 +279,17 @@ function note_clock(track,note,duration,slide_amt)
 		matrix:set("pitch_t"..track, (note - 36)/(127-36))
 	end
 	local note_str = mu.note_num_to_name(note, true)
-	screen_graphics:add_history(track, note_str, clock.get_beats())
+	local description = player:describe()
 	for i=1,subdivision do
 		if params:get('data_subtrig_'..i..'_step_'..pos..'_t'..track..'_p'..ap()) == 1 then
-			player:set_slew(slide_amt/1000)
+			if description.supports_slew then
+				local slide_amt = util.linlin(1,7,1,120,slide_or_modulate) -- to match stock kria times
+				player:set_slew(slide_amt/1000)
+			else
+				player:modulate(util.linlin(1,7,0,1,slide_or_modulate))
+			end
 			player:play_note(note, velocity, duration/subdivision)
+			screen_graphics:add_history(track, note_str, clock.get_beats())
 		end
 		clock.sleep(clock.get_beat_sec()*divider/(4*subdivision))
 	end
@@ -344,6 +350,17 @@ function get_page_name()
 		p = alt_page_names[params:get('page')]
 	else
 		p = page_names[params:get('page')]
+	end
+	return p
+end
+
+function get_display_page_name()
+	local p = get_page_name()
+	if p == "slide" then
+		local description = params:lookup_param("voice_t"..at()):get_player():describe()
+		if not description.supports_slew then
+			p = description.modulate_description
+		end
 	end
 	return p
 end

--- a/lib/gkeys.lua
+++ b/lib/gkeys.lua
@@ -60,7 +60,7 @@ function gkeys:page_select(x,y,z,t)
 		params:set('page',page_map[x])
 		params:set('alt_page',0)
 	end
-	post(get_page_name())
+	post(get_display_page_name())
 end
 
 function gkeys:resolve_mod_keys(x,y,z,t) -- intentionally prioritizes leftmost held mod key
@@ -121,7 +121,7 @@ function gkeys:time_mod(x,y,z,t)
 
 		local g1 = params:get('note_div_sync')
 		local g2 = params:get('div_sync')
-		local pn = get_page_name()
+		local pn = get_page_name(false)
 
 		if g1 == 0 and g2 == 1 then -- off/none
 			meta:edit_divisor(at(),pn,x)
@@ -207,7 +207,6 @@ function gkeys:trig_page(x,y,z,t)
 end
 
 function gkeys:retrig_page(x,y,z,t)
-	local p = get_page_name()
 	if y == 1 or y == 7 then
 		meta:delta_subtrig_count(t,x,(y==1 and 1 or -1))
 	else
@@ -247,7 +246,13 @@ end
 
 function gkeys:slide_page(x,y,z,t)
 	data:set_step_val(t,'slide',x,8-y)
-	post('slide '..x..': '..8-y)
+	local player = params:lookup_param("voice_t"..t):get_player()
+	local description = player:describe()
+	if description.supports_slew then
+		post('slide '..x..': '..8-y)
+	else
+		post(description.modulate_description .. ' ' .. x .. ": "..8-y)
+	end
 end
 
 function gkeys:gate_page(x,y,z,t)

--- a/lib/meta.lua
+++ b/lib/meta.lua
@@ -23,7 +23,7 @@ function Meta:note_out(t)
 	local gate_len = current_val(t,'gate') -- this will give you a weird range, feel free to use it however you want
 	-- local gate_multiplier = params:get('data_gate_shift_t'..t) 
 	local gate_multiplier = data:get_track_val(t,'gate_shift')
-	local slide_amt =  util.linlin(1,7,1,120,current_val(t,'slide')) -- to match stock kria times
+	local slide_or_modulate = current_val(t,'slide') -- to match stock kria times
 	local duration = util.clamp(gate_len-1, 0, 4)/16
 	if gate_len == 1 or gate_len == 6 then
 		duration = duration + 0.02 -- this turns the longest notes into ties, and the shortest into blips, at mult of 1
@@ -31,7 +31,7 @@ function Meta:note_out(t)
 		duration = duration - 0.02
 	end
 	duration = duration * gate_multiplier
-	clock.run(note_clock, t, n, duration, slide_amt)
+	clock.run(note_clock, t, n, duration, slide_or_modulate)
 end
 
 function Meta:advance_all()
@@ -154,10 +154,10 @@ end
 function Meta:edit_divisor(track,page,new_val)
 	if params:get('div_cue') == 1 then
 		data:set_page_val(track,page,'cued_divisor',new_val)
-		post('cued: '..page..' divisor: '..division_names[new_val])
+		post('cued: '..get_display_page_name()..' divisor: '..division_names[new_val])
 	else
 		data:set_page_val(track,page,'divisor',new_val)
-		post(page..' divisor: '..division_names[new_val])
+		post(get_display_page_name()..' divisor: '..division_names[new_val])
 	end
 end
 
@@ -177,7 +177,7 @@ function Meta:edit_loop(track, first, last)
 		else
 			data:set_page_val(track,p,'loop_first',f)
 			data:set_page_val(track,p,'loop_last',l)
-			post('t'..track..' '..p..' loop: ['..f..'-'..l..']')
+			post('t'..track..' '..get_display_page_name()..' loop: ['..f..'-'..l..']')
 		end
 	elseif loopsync == 'track' then
 		for k,v in ipairs(combined_page_list) do


### PR DESCRIPTION
With this PR (which also requires updating emplaitress to use it with emplaitress), what was previously the "slide" page will now control slide only if the voice supports slide. 

Otherwise, it'll check the voice for what modulation parameter it _does_ support by default as the modulate method, and use that. For emplaitress, that's `timbre`. 