### PR TITLE
Slight retooling of stretch and push parameters

### DIFF
--- a/lib/meta.lua
+++ b/lib/meta.lua
@@ -3,6 +3,8 @@ WHAT GOES IN THIS FILE:
 - utility, sanity and sugar functions
 - for global use
 ]]--
+local status, matrix = pcall(require, 'matrix/lib/matrix')
+if not status then matrix = nil end
 
 Meta = {}
 
@@ -43,6 +45,16 @@ function Meta:update_last_notes()
 	for t=1,NUM_TRACKS do
 		local b = value_buffer[t]
 		local n = b.note
+		if matrix ~= nil then
+			matrix:set("note_t"..t, (n-1)/6)
+			if t==2 then
+				print("setting note", n, (n-1)/6)
+			end
+		end
+	end
+	for t=1,NUM_TRACKS do
+		local b = value_buffer[t]
+		local n = b.note
 		n = n + b.transpose-1
 		-- The "stretch" parameter attempts to exttend a melody around its
 		-- center. We assume the center is going to be the root note
@@ -58,6 +70,7 @@ function Meta:update_last_notes()
 
 		if params:get('pushable_t'..t) == 1 then
 			n = n + params:get('push')
+			print("push", params:get('push'), n)
 		end
 
 		local s = self:make_scale()

--- a/lib/meta.lua
+++ b/lib/meta.lua
@@ -47,9 +47,6 @@ function Meta:update_last_notes()
 		local n = b.note
 		if matrix ~= nil then
 			matrix:set("note_t"..t, (n-1)/6)
-			if t==2 then
-				print("setting note", n, (n-1)/6)
-			end
 		end
 	end
 	for t=1,NUM_TRACKS do
@@ -70,7 +67,6 @@ function Meta:update_last_notes()
 
 		if params:get('pushable_t'..t) == 1 then
 			n = n + params:get('push')
-			print("push", params:get('push'), n)
 		end
 
 		local s = self:make_scale()

--- a/lib/meta.lua
+++ b/lib/meta.lua
@@ -44,10 +44,18 @@ function Meta:update_last_notes()
 		local b = value_buffer[t]
 		local n = b.note
 		n = n + b.transpose-1
-		n = n + 7*(b.octave + (data:get_track_val(t,'octave_shift')-1))
+		-- The "stretch" parameter attempts to exttend a melody around its
+		-- center. We assume the center is going to be the root note
+		-- of octive 3, not counting the octave shift of the track.
+
+		-- Subtract three octaves before stretch
+		n = n + 7*(b.octave - 3)
 		if params:get('stretchable_t'..t) == 1 then
-			n = util.round(n*((params:get('stretch')/64)+1))
+			n = util.round((n-1)*((params:get('stretch')/8)+1)) + 1
 		end
+		-- Add them back after.
+		n = n + 7*(3 + data:get_track_val(t,'octave_shift')-1)
+
 		if params:get('pushable_t'..t) == 1 then
 			n = n + params:get('push')
 		end

--- a/lib/prms.lua
+++ b/lib/prms.lua
@@ -14,10 +14,10 @@ function Prms:add()
 	params:add_number('root_note','ROOT NOTE',0,11,0,
 		function(x) return mu.note_num_to_name(x.value) end
 	)
-	params:add_number('stretch','STRETCH',-64,64,0,
+	params:add_number('stretch','STRETCH',-32,32,0,
 		function(x) return x.value > 0 and '+'..x.value or x.value end
 	)
-	params:add_number('push','PUSH',-64,64,0,
+	params:add_number('push','PUSH',-13,14,0,
 		function(x) return x.value > 0 and '+'..x.value or x.value end
 	)
 	params:add_number('swing','SWING',50,99,55,function(x) return x.value..'%' end)

--- a/lib/prms.lua
+++ b/lib/prms.lua
@@ -17,7 +17,7 @@ function Prms:add()
 	params:add_number('stretch','STRETCH',-32,32,0,
 		function(x) return x.value > 0 and '+'..x.value or x.value end
 	)
-	params:add_number('push','PUSH',-13,14,0,
+	params:add_number('push','PUSH',-15,14,0,
 		function(x) return x.value > 0 and '+'..x.value or x.value end
 	)
 	params:add_number('swing','SWING',50,99,55,function(x) return x.value..'%' end)

--- a/n.kria.lua
+++ b/n.kria.lua
@@ -255,7 +255,10 @@ end
 function add_modulation_sources()
 	if matrix == nil then return end
 	for i=1,NUM_TRACKS do
-		matrix:add_binary("pitch_t"..i, "track "..i.." cv")
+		-- The final pitch
+		matrix:add_bipolar("pitch_t"..i, "track "..i.." cv")
+		-- The raw note, unaffected by transpose or anything
+		matrix:add_unipolar("note_t"..i, "track "..i.." note")
 	end
 end
 


### PR DESCRIPTION
This had two goals:

* For stretch, I wanted to be able to reduce stretch to a point at which we only played one root note, and have it be a reasonable root note for the melody. I also wanted to be able to invert melodies. I did this by reducing the range of stretch, and setting it to center around the root note at the octave offset for the track.
* For push, I wanted it to be reasonable to use `matrix` to modulate `push` to transpose another entire sequence within the scale so that, for example, sequence 1 can play an arp and sequence 2 can play a bass and the bass can control what chord the arp plays. I added a modulator for this. Here's how to do it:
 - Make the bass *not* pushable.
 - Set the bass clock divider high, so it plays fewer notes in the sequence.
 - Modulate push by the "note" modulator from the bass track. The modulation amount should be 0.2.
 - Now all pushable tracks will transpose in-scale with the bass.

The very first note in the other track might not actually be transposed. There's some kind of issue in terms of when new notes get set that I have not quite worked out — it feels like the bass is sounding at the same time as the first note in the other track, but it's possible the note in the other track could be playing technically-first so it doesn't pick up the bass note. But anyway, this is cool and mostly works.