### PR TITLE
Sync delay

### DIFF
--- a/lib/dualdelay.lua
+++ b/lib/dualdelay.lua
@@ -1,22 +1,46 @@
 local sc = {}
 
+local beat_amounts = {
+	"sixteenth", 
+	"eighth triplet", 
+	"dotted sixteenth", 
+	"eighth", 
+	"triplet", 
+	"dotted eighth", 
+	"quarter", 
+	"dotted quarter"
+}
+
+local beat_values = {
+	1/4,
+	1/3,
+	3/8,
+	1/2,
+	2/3,
+	3/4,
+	1,
+	3/2,
+}
+
+local loop_length = 0.5
+
 function sc.init()
 	audio.level_cut(1.0)
 	audio.level_adc_cut(1)
 	audio.level_eng_cut(1)
-	
+
 	-- 1
-	softcut.level(1,1.0)
-	softcut.level_slew_time(1,0)
+	softcut.level(1, 1.0)
+	softcut.level_slew_time(1, 0)
 	softcut.level_input_cut(1, 1, 1.0)
 	softcut.level_input_cut(2, 1, 1.0)
 	softcut.pan(1, 1)
 
 	softcut.play(1, 1)
 	softcut.rate(1, 1)
-	softcut.rate_slew_time(1,0)
+	softcut.rate_slew_time(1, 0)
 	softcut.loop_start(1, 1)
-	softcut.loop_end(1, 1.5)
+	softcut.loop_end(1, 1 + loop_length)
 	softcut.loop(1, 1)
 	softcut.fade_time(1, 0.1)
 	softcut.rec(1, 1)
@@ -32,17 +56,17 @@ function sc.init()
 	softcut.filter_rq(1, 2.0);
 
 	-- 2
-	softcut.level(2,1.0)
-	softcut.level_slew_time(2,0)
+	softcut.level(2, 1.0)
+	softcut.level_slew_time(2, 0)
 	softcut.level_input_cut(1, 2, 1.0)
 	softcut.level_input_cut(2, 2, 1.0)
 	softcut.pan(2, -1)
 
 	softcut.play(2, 1)
 	softcut.rate(2, 1)
-	softcut.rate_slew_time(2,0.25)
+	softcut.rate_slew_time(2, 0.25)
 	softcut.loop_start(2, 1)
-	softcut.loop_end(2, 1.5)
+	softcut.loop_end(2, 1 + loop_length)
 	softcut.loop(2, 1)
 	softcut.fade_time(2, 0.1)
 	softcut.rec(2, 1)
@@ -60,56 +84,83 @@ function sc.init()
 	add_sc_params()
 end
 
-function add_sc_params()
-	params:add_group("DELAY",7)
+function set_delay_rate()
+	local base_rate
+	if params:get("delay_style") == 1 then
+		-- rate
+		base_rate = params:get("delay_rate")
+	elseif params:get("delay_style") == 2 then
+		local beat_sec = clock.get_beat_sec()
+		local delay_value = beat_values[params:get("delay_beats")]
+		local delay_duration = beat_sec * delay_value
+		base_rate = loop_length/delay_duration
+	end
+	softcut.rate(1, base_rate * 2^params:get('delay_skew'))
+	softcut.rate(2, base_rate * 2^(-params:get('delay_skew')))
+end
 
-  	params:add{id="delay", name="level", type="control", 
-    	controlspec=controlspec.new(0,1,'lin',0,0.5,""),
-    	action=function(x) 
-			softcut.level(1,x) 
-			softcut.level(2,x) 
+function add_sc_params()
+	params:add_group("DELAY", 9)
+
+	params:add { id = "delay", name = "level", type = "control",
+		controlspec = controlspec.new(0, 1, 'lin', 0, 0.5, ""),
+		action = function(x)
+			softcut.level(1, x)
+			softcut.level(2, x)
 		end
 	}
-	params:add{id="delay_cutoff", name="band center", type="control",
-		controlspec=controlspec.WIDEFREQ,
-		action=function(x)
-			softcut.filter_fc(1,x)
-			softcut.filter_fc(2,x)
+	params:add { id = "delay_cutoff", name = "band center", type = "control",
+		controlspec = controlspec.WIDEFREQ,
+		action = function(x)
+			softcut.filter_fc(1, x)
+			softcut.filter_fc(2, x)
 		end
 	}
-	params:add{id="delay_q", name="band width", type="control",
-		controlspec=controlspec.new(0.1,4.0,'lin',0.1,2,""),
-		action=function(x)
-			softcut.filter_rq(1,x)
-			softcut.filter_rq(2,x)
+	params:add { id = "delay_q", name = "band width", type = "control",
+		controlspec = controlspec.new(0.1, 4.0, 'lin', 0.1, 2, ""),
+		action = function(x)
+			softcut.filter_rq(1, x)
+			softcut.filter_rq(2, x)
 		end
 	}
-  	params:add{id="delay_rate", name="delay rate", type="control", 
-    	controlspec=controlspec.new(0.1,2.0,'exp',0.01,1,""),
-    	action=function(x)
-			softcut.rate(1,x-params:get('delay_skew')) 
-			softcut.rate(2,x+params:get('delay_skew'))
+	params:add_option("delay_style", "style", {"free", "sync"}, 1)
+	params:set_action("delay_style", function() 
+		if params:get("delay_style") == 1 then
+			params:hide("delay_beats")
+			params:show("delay_rate")
+		elseif params:get("delay_style") == 2 then
+			params:hide("delay_rate")
+			params:show("delay_beats")
+		end
+		_menu.rebuild_params()
+		set_delay_rate()
+	end)
+	params:add { id = "delay_rate", name = "delay rate", type = "control",
+		controlspec = controlspec.new(0.1, 2.0, 'exp', 0, 1, "", 0.002),
+		action = set_delay_rate
+	}
+	params:add_option(
+		"delay_beats", 
+		"delay beats", 
+		beat_amounts, 6)
+	params:set_action("delay_beats", set_delay_rate)
+
+	params:add { id = "delay_skew", name = "delay skew", type = "control",
+		controlspec = controlspec.new(-1.0, 1.0, 'lin', 0, 0, '', 0.002),
+		action = set_delay_rate
+	}
+	params:add { id = "delay_feedback", name = "delay feedback", type = "control",
+		controlspec = controlspec.new(0, 1.0, 'lin', 0, 0.75, ""),
+		action = function(x)
+			softcut.pre_level(1, x)
+			softcut.pre_level(2, x)
 		end
 	}
-	params:add{id="delay_skew", name="delay skew", type="control",
-		controlspec=controlspec.new(-1.0,1.0,'lin',0.01,0),
-		action=function(x)
-			softcut.rate(1,x+params:get('delay_rate'))
-			softcut.rate(2,x-params:get('delay_rate'))
-		end
-	}
-  	params:add{id="delay_feedback", name="delay feedback", type="control", 
-    	controlspec=controlspec.new(0,1.0,'lin',0,0.75,""),
-    	action=function(x) 
-			softcut.pre_level(1,x) 
-			softcut.pre_level(2,x)
-		end
-	}
-  	params:add{id="delay_width", name="delay width", type="control", 
-    	controlspec=controlspec.new(0.0,1.0,'lin',0,0,""),
-    	action=function(x) 
-			softcut.pan(1,-x) 
-			softcut.pan(1,x) 
+	params:add { id = "delay_width", name = "delay width", type = "control",
+		controlspec = controlspec.new(0.0, 1.0, 'lin', 0, 0, ""),
+		action = function(x)
+			softcut.pan(1, -x)
+			softcut.pan(2, x)
 		end
 	}
 end

--- a/lib/dualdelay.lua
+++ b/lib/dualdelay.lua
@@ -94,6 +94,7 @@ function set_delay_rate()
 		local delay_value = beat_values[params:get("delay_beats")]
 		local delay_duration = beat_sec * delay_value
 		base_rate = loop_length/delay_duration
+		params:set("delay_rate", base_rate)
 	end
 	softcut.rate(1, base_rate * 2^params:get('delay_skew'))
 	softcut.rate(2, base_rate * 2^(-params:get('delay_skew')))
@@ -157,7 +158,7 @@ function add_sc_params()
 		end
 	}
 	params:add { id = "delay_width", name = "delay width", type = "control",
-		controlspec = controlspec.new(0.0, 1.0, 'lin', 0, 0, ""),
+		controlspec = controlspec.new(0.0, 1.0, 'lin', 0, 1, ""),
 		action = function(x)
 			softcut.pan(1, -x)
 			softcut.pan(2, x)

--- a/lib/dualdelay.lua
+++ b/lib/dualdelay.lua
@@ -1,25 +1,25 @@
 local sc = {}
 
 local beat_amounts = {
-	"sixteenth", 
-	"eighth triplet", 
-	"dotted sixteenth", 
-	"eighth", 
-	"triplet", 
-	"dotted eighth", 
-	"quarter", 
+	"sixteenth",
+	"eighth triplet",
+	"dotted sixteenth",
+	"eighth",
+	"triplet",
+	"dotted eighth",
+	"quarter",
 	"dotted quarter"
 }
 
 local beat_values = {
-	1/4,
-	1/3,
-	3/8,
-	1/2,
-	2/3,
-	3/4,
+	1 / 4,
+	1 / 3,
+	3 / 8,
+	1 / 2,
+	2 / 3,
+	3 / 4,
 	1,
-	3/2,
+	3 / 2,
 }
 
 local loop_length = 0.5
@@ -93,11 +93,11 @@ function set_delay_rate()
 		local beat_sec = clock.get_beat_sec()
 		local delay_value = beat_values[params:get("delay_beats")]
 		local delay_duration = beat_sec * delay_value
-		base_rate = loop_length/delay_duration
+		base_rate = loop_length / delay_duration
 		params:set("delay_rate", base_rate)
 	end
-	softcut.rate(1, base_rate * 2^params:get('delay_skew'))
-	softcut.rate(2, base_rate * 2^(-params:get('delay_skew')))
+	softcut.rate(1, base_rate * 2 ^ params:get('delay_skew'))
+	softcut.rate(2, base_rate * 2 ^ (-params:get('delay_skew')))
 end
 
 function add_sc_params()
@@ -124,8 +124,8 @@ function add_sc_params()
 			softcut.filter_rq(2, x)
 		end
 	}
-	params:add_option("delay_style", "style", {"free", "sync"}, 1)
-	params:set_action("delay_style", function() 
+	params:add_option("delay_style", "style", { "free", "sync" }, 1)
+	params:set_action("delay_style", function()
 		if params:get("delay_style") == 1 then
 			params:hide("delay_beats")
 			params:show("delay_rate")
@@ -141,8 +141,8 @@ function add_sc_params()
 		action = set_delay_rate
 	}
 	params:add_option(
-		"delay_beats", 
-		"delay beats", 
+		"delay_beats",
+		"delay beats",
 		beat_amounts, 6)
 	params:set_action("delay_beats", set_delay_rate)
 

--- a/n.kria.lua
+++ b/n.kria.lua
@@ -231,6 +231,7 @@ function g.key(x,y,z) gkeys:key(x,y,z) end
 
 function clock.transport.start() params:set('playing',1); post('play') end
 function clock.transport.stop() params:set('playing',0); post('stop') end
+function clock.tempo_change_handler() set_delay_rate() end
 
 function post(str) post_buffer = str end
 


### PR DESCRIPTION
* Allow two modes for delay: free and tempo-sync. Tempo-sync allows you to choose a note value for the delay time.
* Tempo-sync mode tracks BPM, so expect doppler effects when you change BPM
* Change the way delay skew works such that the extremes (-1, 1) no longer stall one delay and double the other, instead they halve one delay and double the other. Valuable amounts to set it to now include 0, plus/minus small numbers, plus/minus 0.42 (log2(4/3)) and plus/minus 0.58 (log2(3/2))
* Fix bug in delay stereo spread so that it actually happens.
* Set default for stereo spread to be 1. Previously it was 0, which would mix the two voices causing phase cancellation effects at low skew. Now it sounds like pleasant stereo width at low skew.